### PR TITLE
chore: update Kruize image versions

### DIFF
--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   # Supported values: "openshift", "minikube", "kind"
   cluster_type: "openshift"
-  autotune_image: "quay.io/kruize/autotune_operator:0.8.1"
+  autotune_image: "quay.io/kruize/autotune_operator:0.8.2"
   autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9"
   # For OpenShift, use: "openshift-tuning", Minikube/KIND, use: "monitoring"
   namespace: "openshift-tuning"

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -30,7 +30,7 @@ const (
 // Default container image versions
 const (
 	// defaultAutotuneImageTag is the default tag for Kruize Autotune image
-	defaultAutotuneImageTag = "0.8.1"
+	defaultAutotuneImageTag = "0.8.2"
 	
 	// defaultUIImageTag is the default tag for Kruize UI image
 	defaultUIImageTag = "0.0.9"


### PR DESCRIPTION
## Automated Version Update

Updates Kruize image versions from upstream repositories.

**Autotune**: 0.8.1 → 0.8.2
**UI**: 0.0.9 → 0.0.9

- Images verified on quay.io ✓